### PR TITLE
fix "Error: Redefinition of RCTMethodInfo"

### DIFF
--- a/ReactNativeImageCropping.h
+++ b/ReactNativeImageCropping.h
@@ -1,6 +1,12 @@
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#import "TOCropView.h"
+#import <React/RCTImageLoader.h>
+#else
 #import "RCTBridgeModule.h"
 #import "TOCropView.h"
-#import <RCTImageLoader.h>
+#import "RCTImageLoader.h"
+#endif
 
 @interface ReactNativeImageCropping : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
following https://github.com/facebook/react-native/issues/15775
and this PR - https://github.com/nico1510/react-native-image-crop-picker/pull/9/files

it works for me this way
i am not sure about the right order for TOCropView.h, just kept it between