### PR TITLE
Changed import of RCTBridgeModule

### DIFF
--- a/ReactNativeImageCropping.h
+++ b/ReactNativeImageCropping.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import "TOCropView.h"
 #import <RCTImageLoader.h>
 


### PR DESCRIPTION
This is to correspond with React Native 0.48. It no longer works with #import "RCTBridgeModule.h" (see this issue: https://github.com/facebook/react-native/issues/15775). This fixes issue.